### PR TITLE
Added basic support for Qt5

### DIFF
--- a/LICENCE.GPL3
+++ b/LICENCE.GPL3
@@ -1,0 +1,675 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    {one line to give the program's name and a brief idea of what it does.}
+    Copyright (C) {year}  {name of author}
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    {project}  Copyright (C) {year}  {fullname}
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,50 @@
-# Stoiridh-CMake-Tools
-Collection of CMake scripts
+# Stòiridh CMake Tools
+
+Collection of CMake scripts.
+
+# Example
+
+```cmake
+cmake_minimum_required(VERSION 3.5.0 FATAL_ERROR)
+
+# Project
+project("ProjectExample" VERSION 0.1.0)
+
+# Configuration
+set(STOIRIDH_PROJECT_NAME "ProjectExample")
+set(STOIRIDH_CONFIGURATION_ROOT "${PROJECT_SOURCE_DIR}/config/cmake")
+
+include("${STOIRIDH_CONFIGURATION_ROOT}/StoiridhConfiguration.cmake")
+stoiridh_project_initialise()
+
+# Subdirectories
+add_subdirectory("src")
+
+if(STOIRIDH_PROJECT_TESTING_ENABLE)
+    enable_testing()
+    add_subdirectory("tests")
+endif()
+```
+
+# Requirements
+
+|                Name               | Minimum Version Required |
+|:---------------------------------:|:------------------------:|
+| [CMake](https://cmake.org/)       |          3.5.0           |
+
+# Licence
+
+The project is licenced under the GPL version 3. See [LICENCE.GPL3](https://github.com/viprip/Stoiridh-CMake-Tools/blob/master/LICENCE.GPL3) located at the root of the project for more information.
+
+> This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+> This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+> You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/StoiridhConfiguration.cmake
+++ b/StoiridhConfiguration.cmake
@@ -1,0 +1,90 @@
+####################################################################################################
+##                                                                                                ##
+##            Copyright (C) 2016 William McKIE                                                    ##
+##                                                                                                ##
+##            This program is free software: you can redistribute it and/or modify                ##
+##            it under the terms of the GNU General Public License as published by                ##
+##            the Free Software Foundation, either version 3 of the License, or                   ##
+##            (at your option) any later version.                                                 ##
+##                                                                                                ##
+##            This program is distributed in the hope that it will be useful,                     ##
+##            but WITHOUT ANY WARRANTY; without even the implied warranty of                      ##
+##            MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                       ##
+##            GNU General Public License for more details.                                        ##
+##                                                                                                ##
+##            You should have received a copy of the GNU General Public License                   ##
+##            along with this program.  If not, see <http://www.gnu.org/licenses/>.               ##
+##                                                                                                ##
+####################################################################################################
+include("${STOIRIDH_CONFIGURATION_ROOT}/internal/configuration.cmake")
+
+####################################################################################################
+##  stoiridh_project_initialise()                                                                 ##
+##------------------------------------------------------------------------------------------------##
+##                                                                                                ##
+##  Initialise the cache and the common options used by the Stòiridh Project.                     ##
+##                                                                                                ##
+##  Note: This function must be set at the top-level of the project.                              ##
+##                                                                                                ##
+####################################################################################################
+function(STOIRIDH_PROJECT_INITIALISE)
+    _stoiridh_project_initialise_options()
+    _stoiridh_project_initialise_cache()
+
+    # Operating System detection
+    if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+        set(STOIRIDH_OS_WINDOWS YES CACHE INTERNAL "Operating system")
+    elseif(CMAKE_SYSTEM_NAME MATCHES "Linux")
+        set(STOIRIDH_OS_LINUX YES CACHE INTERNAL "Operating system")
+    endif()
+endfunction()
+####################################################################################################
+##  stoiridh_include(<module name> [INTERNAL])                                                    ##
+##------------------------------------------------------------------------------------------------##
+##                                                                                                ##
+##  Load and run CMake code from the specified <module name> file.                                ##
+##                                                                                                ##
+##  A module is coumpound of the following form: <namespace>.<module_name>. The namespace         ##
+##  corresponds to the path where the module is located with a dotted URI notation and the        ##
+##  <module name> corresponds to the CMake file without the .cmake suffix.                        ##
+##                                                                                                ##
+##  If the INTERNAL option is specified, the module will be search in the internal path of the    ##
+##  STOIRIDH_CONFIGURATION_ROOT variable, otherwise, in the public path.                          ##
+##                                                                                                ##
+##  Example:                                                                                      ##
+##      stoiridh_include("Stoiridh.Qt.Application")                                               ##
+##      is equivalent to                                                                          ##
+##      include("${STOIRIDH_CONFIGURATION_ROOT}/public/Stoiridh/Qt/Application.cmake")            ##
+##                                                                                                ##
+##  Note: The STOIRIDH_CONFIGURATION_ROOT variable must be set - ideally at the top-level of the  ##
+##        project - before using this function.                                                   ##
+##                                                                                                ##
+####################################################################################################
+function(STOIRIDH_INCLUDE module_name)
+    set(OPTIONS "INTERNAL")
+    cmake_parse_arguments(STOIRIDH_COMMAND "${OPTIONS}" "" "" ${ARGN})
+
+    # replace dots by CMake path separators.
+    string(REPLACE "." "/" MODULE_NAME_NORMALISED ${module_name})
+
+    if(NOT STOIRIDH_CONFIGURATION_ROOT)
+        message(FATAL_ERROR "STOIRIDH_CONFIGURATION_ROOT is not set.")
+    endif()
+
+    set(MODULE "${STOIRIDH_CONFIGURATION_ROOT}")
+
+    if(STOIRIDH_COMMAND_INTERNAL)
+        set(MODULE "${MODULE}/internal")
+    else()
+        set(MODULE "${MODULE}/public")
+    endif()
+
+    set(MODULE "${MODULE}/${MODULE_NAME_NORMALISED}")
+
+    if(NOT module_name MATCHES "[A-Za-z0-9_]+.cmake")
+        set(MODULE "${MODULE}.cmake")
+    endif()
+
+    include(${MODULE})
+    unset(MODULE)
+endfunction()

--- a/internal/Stoiridh/Qt/Helper.cmake
+++ b/internal/Stoiridh/Qt/Helper.cmake
@@ -1,0 +1,73 @@
+####################################################################################################
+##                                                                                                ##
+##            Copyright (C) 2016 William McKIE                                                    ##
+##                                                                                                ##
+##            This program is free software: you can redistribute it and/or modify                ##
+##            it under the terms of the GNU General Public License as published by                ##
+##            the Free Software Foundation, either version 3 of the License, or                   ##
+##            (at your option) any later version.                                                 ##
+##                                                                                                ##
+##            This program is distributed in the hope that it will be useful,                     ##
+##            but WITHOUT ANY WARRANTY; without even the implied warranty of                      ##
+##            MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                       ##
+##            GNU General Public License for more details.                                        ##
+##                                                                                                ##
+##            You should have received a copy of the GNU General Public License                   ##
+##            along with this program.  If not, see <http://www.gnu.org/licenses/>.               ##
+##                                                                                                ##
+####################################################################################################
+##  stoiridh_qt_helper(<APPLICATION|LIBRARY> <target>                                             ##
+##                     SOURCES <source1> [<source2>...]                                           ##
+##                     DEPENDS <dependency1> [<dependency2>...]                                   ##
+##                     [OTHER_FILES <file1> [<file2>...]]                                         ##
+##                     [USE_QT_PRIVATE_API])                                                      ##
+##                                                                                                ##
+##------------------------------------------------------------------------------------------------##
+##                                                                                                ##
+##  This helper function groups the common features in order to make either an application or a   ##
+##  shared library.                                                                               ##
+##                                                                                                ##
+####################################################################################################
+function(stoiridh_qt_helper command target)
+    set(COMMANDS "APPLICATION" "LIBRARY")
+    set(OPTIONS "USE_QT_PRIVATE_API")
+    set(MVK "SOURCES" "DEPENDS" "OTHER_FILES")
+    cmake_parse_arguments(STOIRIDH_COMMAND "${OPTIONS}" "" "${MVK}" ${ARGN})
+
+    if(NOT command IN_LIST COMMANDS)
+        message(FATAL_ERROR "stoiridh_qt_helper(${command}): invalid command.")
+    endif()
+
+    if(NOT STOIRIDH_COMMAND_SOURCES)
+        message(FATAL_ERROR "stoiridh_qt_helper(${command}): SOURCES is missing or not defined.")
+    endif()
+
+    if(NOT STOIRIDH_COMMAND_DEPENDS)
+        message(FATAL_ERROR "stoiridh_qt_helper(${command}): DEPENDS is missing or not defined.")
+    endif()
+
+    # include the private headers from the Qt API to ${target} if the USE_QT_PRIVATE_API option is
+    # given.
+    if(STOIRIDH_COMMAND_USE_QT_PRIVATE_API)
+        foreach(DEPENDENCY ${STOIRIDH_COMMAND_DEPENDS})
+            if(DEPENDENCY MATCHES "^Qt5::[0-9A-Za-z]+$")
+                string(REPLACE "::" "" QT5_LIBRARY_MODULE ${DEPENDENCY})
+                include_directories(${${QT5_LIBRARY_MODULE}_PRIVATE_INCLUDE_DIRS})
+            endif()
+        endforeach()
+    endif()
+
+    if(command STREQUAL "APPLICATION")
+        add_executable(${target} ${STOIRIDH_COMMAND_SOURCES})
+    elseif(command STREQUAL "LIBRARY")
+        add_library(${target} SHARED ${STOIRIDH_COMMAND_SOURCES})
+    endif()
+
+    target_link_libraries(${target} ${STOIRIDH_COMMAND_DEPENDS})
+    set_target_properties(${target} PROPERTIES CXX_STANDARD 14 CXX_STANDARD_REQUIRED YES)
+
+    # add extra files that will not be compiled.
+    if(STOIRIDH_COMMAND_OTHER_FILES)
+        add_custom_target("${target}_OTHER_FILES" SOURCES ${STOIRIDH_COMMAND_OTHER_FILES})
+    endif()
+endfunction()

--- a/internal/Stoiridh/Utility/Header.cmake
+++ b/internal/Stoiridh/Utility/Header.cmake
@@ -1,0 +1,156 @@
+####################################################################################################
+##                                                                                                ##
+##            Copyright (C) 2016 William McKIE                                                    ##
+##                                                                                                ##
+##            This program is free software: you can redistribute it and/or modify                ##
+##            it under the terms of the GNU General Public License as published by                ##
+##            the Free Software Foundation, either version 3 of the License, or                   ##
+##            (at your option) any later version.                                                 ##
+##                                                                                                ##
+##            This program is distributed in the hope that it will be useful,                     ##
+##            but WITHOUT ANY WARRANTY; without even the implied warranty of                      ##
+##            MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                       ##
+##            GNU General Public License for more details.                                        ##
+##                                                                                                ##
+##            You should have received a copy of the GNU General Public License                   ##
+##            along with this program.  If not, see <http://www.gnu.org/licenses/>.               ##
+##                                                                                                ##
+####################################################################################################
+stoiridh_include("Stoiridh.Utility.LocalInstall" INTERNAL)
+
+####################################################################################################
+##  stoiridh_utility_header(COPY                                                                  ##
+##                          HEADERS <header1> [<header2>...]                                      ##
+##                          DESTINATION <destination>                                             ##
+##                          [PATH_SUFFIXES <suffix1> [<suffix2>...]])                             ##
+##                                                                                                ##
+##  stoiridh_utility_header(FILTER <output>                                                       ##
+##                          HEADERS <header1> [<header2>...]                                      ##
+##                          SUFFIXES <suffix1> [<suffix2>...])                                    ##
+##                                                                                                ##
+##  stoiridh_utility_header(FILTER_COPY                                                           ##
+##                          HEADERS <header1> [<header2>...]                                      ##
+##                          HEADER_SUFFIXES <suffix1> [<suffix2>...]                              ##
+##                          DESTINATION <absolute path>                                           ##
+##                          [PATH_SUFFIXES <suffix1> [<suffix2>...]])                             ##
+##------------------------------------------------------------------------------------------------##
+##                                                                                                ##
+##  The COPY command copies the header files from the HEADERS list to the DESTINATION path.       ##
+##                                                                                                ##
+##  The PATH_SUFFIXES argument corresponds to a list of relative paths where this function will   ##
+##  concatenate with the CMAKE_CURRENT_LIST_DIR variable in order to avoid the keep those paths   ##
+##  during copying of the header files.                                                           ##
+##                                                                                                ##
+##                                    ========================                                    ##
+##                                                                                                ##
+##  The FILTER command filters the given HEADERS with the given SUFFIXES and put the result of    ##
+##  the filtering into the <output> variable.                                                     ##
+##                                                                                                ##
+##  The SUFFIXES argument corresponds to a list of file suffix of the HEADERS. If a suffix        ##
+##  matches for a given header in the given HEADERS list, then the header will be append to the   ##
+##  <output>.                                                                                     ##
+##                                                                                                ##
+##                                    ========================                                    ##
+##                                                                                                ##
+##  The FILTER_COPY command is a combination of both COPY and FILTER commands. See above, the     ##
+##  COPY and FILTER descriptions, respectively.                                                   ##
+##                                                                                                ##
+####################################################################################################
+function(STOIRIDH_UTILITY_HEADER command)
+    set(COMMANDS "COPY" "FILTER" "FILTER_COPY")
+    set(OVK "DESTINATION")
+    set(MVK "HEADERS" "PATH_SUFFIXES" "SUFFIXES")
+    cmake_parse_arguments(STOIRIDH_COMMAND "" "${OVK}" "${MVK}" ${ARGN})
+
+    if(NOT command IN_LIST COMMANDS)
+        message(FATAL_ERROR "stoiridh_utility_header(${command}): invalid command.")
+    endif()
+
+    if(command STREQUAL "COPY")
+        stoiridh_utility_local_install(FILES ${STOIRIDH_COMMAND_HEADERS}
+                                       DESTINATION ${STOIRIDH_COMMAND_DESTINATION}
+                                       PATH_SUFFIXES ${STOIRIDH_COMMAND_PATH_SUFFIXES})
+    elseif(command STREQUAL "FILTER")
+        _stoiridh_utility_header_filter(FILTER_OUTPUT
+                                        HEADERS ${STOIRIDH_COMMAND_HEADERS}
+                                        SUFFIXES ${STOIRIDH_COMMAND_SUFFIXES})
+        set(${ARGV1} ${FILTER_OUTPUT} PARENT_SCOPE)
+    elseif(command STREQUAL "FILTER_COPY")
+        _stoiridh_utility_header_filter_copy(HEADERS ${STOIRIDH_COMMAND_HEADERS}
+                                             HEADER_SUFFIXES ${STOIRIDH_COMMAND_SUFFIXES}
+                                             PATH_SUFFIXES ${STOIRIDH_COMMAND_PATH_SUFFIXES}
+                                             DESTINATION ${STOIRIDH_COMMAND_DESTINATION})
+    endif()
+endfunction()
+####################################################################################################
+########################################  PRIVATE FUNCTIONS  #######################################
+####################################################################################################
+##  _stoiridh_utility_header_filter(<output>                                                      ##
+##                                  HEADERS <header1> [<header2>...]                              ##
+##                                  SUFFIXES <suffix1> [<suffix2>...])                            ##
+##------------------------------------------------------------------------------------------------##
+##                                                                                                ##
+##  This is a helper function for the stoiridh_utility_header() function.                         ##
+##                                                                                                ##
+####################################################################################################
+function(_STOIRIDH_UTILITY_HEADER_FILTER output)
+    set(MVK "HEADERS" "SUFFIXES")
+    cmake_parse_arguments(STOIRIDH_COMMAND "" "" "${MVK}" ${ARGN})
+
+    if(NOT STOIRIDH_COMMAND_HEADERS)
+        message(FATAL_ERROR "stoiridh_utility_header(FILTER): HEADERS is missing.")
+    endif()
+
+    if(NOT STOIRIDH_COMMAND_SUFFIXES)
+        message(FATAL_ERROR "stoiridh_utility_header(FILTER): SUFFIXES is missing.")
+    endif()
+
+    foreach(HEADER ${STOIRIDH_COMMAND_HEADERS})
+        get_filename_component(HEADER_SUFFIX ${HEADER} EXT)
+        if(HEADER_SUFFIX IN_LIST STOIRIDH_COMMAND_SUFFIXES)
+            list(APPEND HEADERS_LIST ${HEADER})
+        endif()
+    endforeach()
+
+    if(HEADERS_LIST)
+        list(REMOVE_DUPLICATES HEADERS_LIST)
+        set(${output} ${HEADERS_LIST} PARENT_SCOPE)
+    endif()
+endfunction()
+####################################################################################################
+##  _stoiridh_utility_header_filter_copy(HEADERS <header1> [<header2>...]                         ##
+##                                       HEADER_SUFFIXES <suffix1> [<suffix2>...]                 ##
+##                                       DESTINATION <absolute path>                              ##
+##                                       [PATH_SUFFIXES <suffix1> [<suffix2>...]])                ##
+##------------------------------------------------------------------------------------------------##
+##                                                                                                ##
+##  This is a helper function for the stoiridh_utility_header() function. It combines both COPY   ##
+##  and FILTER command.                                                                           ##
+##                                                                                                ##
+####################################################################################################
+function(_STOIRIDH_UTILITY_HEADER_FILTER_COPY)
+    set(OVK "DESTINATION")
+    set(MVK "HEADERS" "HEADER_SUFFIXES" "PATH_SUFFIXES")
+    cmake_parse_arguments(STOIRIDH_COMMAND "" "${OVK}" "${MVK}" ${ARGN})
+
+    if(NOT STOIRIDH_COMMAND_HEADERS)
+        message(FATAL_ERROR "_stoiridh_utility_header_filter_copy: "
+                            "HEADERS is missing or is an empty list.")
+    endif()
+
+    if(NOT STOIRIDH_COMMAND_HEADER_SUFFIXES)
+        message(FATAL_ERROR "_stoiridh_utility_header_filter_copy: HEADER_SUFFIXES is missing.")
+    endif()
+
+    if(NOT STOIRIDH_COMMAND_DESTINATION)
+        message(FATAL_ERROR "_stoiridh_utility_header_filter_copy: DESTINATION is missing.")
+    endif()
+
+    stoiridh_utility_header(FILTER
+                            HEADERS ${STOIRIDH_COMMAND_HEADERS}
+                            SUFFIXES ${STOIRIDH_COMMAND_HEADER_SUFFIXES})
+    stoiridh_utility_header(COPY
+                            HEADERS ${HEADERS}
+                            DESTINATION ${STOIRIDH_COMMAND_DESTINATION}
+                            PATH_SUFFIXES ${STOIRIDH_COMMAND_PATH_SUFFIXES})
+endfunction()

--- a/internal/Stoiridh/Utility/LocalInstall.cmake
+++ b/internal/Stoiridh/Utility/LocalInstall.cmake
@@ -1,0 +1,96 @@
+####################################################################################################
+##                                                                                                ##
+##            Copyright (C) 2016 William McKIE                                                    ##
+##                                                                                                ##
+##            This program is free software: you can redistribute it and/or modify                ##
+##            it under the terms of the GNU General Public License as published by                ##
+##            the Free Software Foundation, either version 3 of the License, or                   ##
+##            (at your option) any later version.                                                 ##
+##                                                                                                ##
+##            This program is distributed in the hope that it will be useful,                     ##
+##            but WITHOUT ANY WARRANTY; without even the implied warranty of                      ##
+##            MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                       ##
+##            GNU General Public License for more details.                                        ##
+##                                                                                                ##
+##            You should have received a copy of the GNU General Public License                   ##
+##            along with this program.  If not, see <http://www.gnu.org/licenses/>.               ##
+##                                                                                                ##
+####################################################################################################
+##  stoiridh_utility_local_install(FILES <file1> [<file2>...]                                     ##
+##                                 DESTINATION <absolute path>                                    ##
+##                                 [PATH_SUFFIXES <suffix1> [<suffix2>...]])                      ##
+##------------------------------------------------------------------------------------------------##
+##                                                                                                ##
+##  Install a local copy of the files in the destination path.                                    ##
+##                                                                                                ##
+##  The PATH_SUFFIXES argument corresponds to a list of relative paths where this function will   ##
+##  concatenate with the CMAKE_CURRENT_LIST_DIR variable in order to avoid the keep those paths   ##
+##  during copying of the header files.                                                           ##
+##                                                                                                ##
+####################################################################################################
+function(STOIRIDH_UTILITY_LOCAL_INSTALL)
+    set(OVK "DESTINATION")
+    set(MVK "FILES" "PATH_SUFFIXES")
+    cmake_parse_arguments(STOIRIDH_COMMAND "" "${OVK}" "${MVK}" ${ARGN})
+
+    if(NOT STOIRIDH_COMMAND_DESTINATION)
+        message(FATAL_ERROR "stoiridh_utility_local_install: DESTINATION is missing.")
+    endif()
+
+    if(NOT STOIRIDH_COMMAND_FILES)
+        message(FATAL_ERROR "stoiridh_utility_local_install: FILES is missing.")
+    endif()
+
+    foreach(FILE ${STOIRIDH_COMMAND_FILES})
+        get_filename_component(FILE_PATH ${FILE} DIRECTORY)
+
+        if(STOIRIDH_COMMAND_PATH_SUFFIXES)
+            foreach(PATH_SUFFIX ${STOIRIDH_COMMAND_PATH_SUFFIXES})
+                set(PATH "${CMAKE_CURRENT_LIST_DIR}/${PATH_SUFFIX}")
+                string(FIND ${FILE_PATH} ${PATH} RESULT)
+                if(RESULT EQUAL 0 OR RESULT GREATER 0)
+                    __get_relative_path(RELATIVE_FILE_PATH ${PATH} ${FILE} PATH_ONLY)
+                    set(OUTPUT_PATH "${STOIRIDH_COMMAND_DESTINATION}/${RELATIVE_FILE_PATH}")
+                    file(COPY ${FILE} DESTINATION ${OUTPUT_PATH})
+                    set(FOUND TRUE)
+                    break()
+                endif()
+            endforeach()
+        endif()
+
+        if(NOT FOUND)
+            set(PATH "${CMAKE_CURRENT_LIST_DIR}")
+            __get_relative_path(RELATIVE_FILE_PATH ${PATH} ${FILE} PATH_ONLY)
+            set(OUTPUT_PATH "${STOIRIDH_COMMAND_DESTINATION}/${RELATIVE_FILE_PATH}")
+            file(COPY ${FILE} DESTINATION ${OUTPUT_PATH})
+        endif()
+        unset(FOUND)
+    endforeach()
+endfunction()
+####################################################################################################
+########################################  PRIVATE FUNCTIONS  #######################################
+####################################################################################################
+##  __get_relative_path(<output> <base_dir> <file> [PATH_ONLY])                                   ##
+##------------------------------------------------------------------------------------------------##
+##                                                                                                ##
+##  Retrieve the relative path of a <file> from a <base_dir> - an absolute path - and set the     ##
+##  result into the <output> variable.                                                            ##
+##                                                                                                ##
+##  If the PATH_ONLY option is specified the relative path without the filename will be returned  ##
+##  into the <output> variable.                                                                   ##
+##                                                                                                ##
+####################################################################################################
+function(__GET_RELATIVE_PATH output base_dir file)
+    set(OPTIONS "PATH_ONLY")
+    cmake_parse_arguments(STOIRIDH_COMMAND "${OPTIONS}" "" "" ${ARGN})
+
+    file(RELATIVE_PATH RELATIVE_FILE ${base_dir} ${file})
+
+    if(STOIRIDH_COMMAND_PATH_ONLY)
+        file(TO_CMAKE_PATH ${RELATIVE_FILE} RELATIVE_FILE)
+        get_filename_component(RELATIVE_PATH ${RELATIVE_FILE} DIRECTORY)
+        set(${output} ${RELATIVE_PATH} PARENT_SCOPE)
+    else()
+        set(${output} ${RELATIVE_FILE} PARENT_SCOPE)
+    endif()
+endfunction()

--- a/internal/configuration.cmake
+++ b/internal/configuration.cmake
@@ -1,0 +1,81 @@
+####################################################################################################
+##                                                                                                ##
+##            Copyright (C) 2016 William McKIE                                                    ##
+##                                                                                                ##
+##            This program is free software: you can redistribute it and/or modify                ##
+##            it under the terms of the GNU General Public License as published by                ##
+##            the Free Software Foundation, either version 3 of the License, or                   ##
+##            (at your option) any later version.                                                 ##
+##                                                                                                ##
+##            This program is distributed in the hope that it will be useful,                     ##
+##            but WITHOUT ANY WARRANTY; without even the implied warranty of                      ##
+##            MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                       ##
+##            GNU General Public License for more details.                                        ##
+##                                                                                                ##
+##            You should have received a copy of the GNU General Public License                   ##
+##            along with this program.  If not, see <http://www.gnu.org/licenses/>.               ##
+##                                                                                                ##
+####################################################################################################
+include(CMakeDependentOption)
+
+####################################################################################################
+##  _stoiridh_project_initialise_options()                                                        ##
+##------------------------------------------------------------------------------------------------##
+##                                                                                                ##
+##  Initialises the CMake common options used by the Stòiridh Project.                            ##
+##                                                                                                ##
+####################################################################################################
+function(_STOIRIDH_PROJECT_INITIALISE_OPTIONS)
+    # documentation and examples options
+    option(STOIRIDH_PROJECT_DOCUMENTATION_ENABLE "Build the documentation projects." ON)
+    option(STOIRIDH_PROJECT_EXAMPLES_ENABLE "Build the examples projects." ON)
+
+    # testing options
+    option(STOIRIDH_PROJECT_TESTING_ENABLE "Build the unit testing projects" ON)
+    cmake_dependent_option(STOIRIDH_PROJECT_TESTING_ENABLE_INTERNAL
+        "Build the internal unit testing projects." ON
+        "STOIRIDH_PROJECT_TESTING_ENABLE" OFF)
+    cmake_dependent_option(STOIRIDH_PROJECT_TESTING_ENABLE_AUTOTESTS
+        "Build the autotests projects." ON
+        "STOIRIDH_PROJECT_TESTING_ENABLE" OFF)
+endfunction()
+
+####################################################################################################
+##  _stoiridh_project_initialise_cache()                                                          ##
+##------------------------------------------------------------------------------------------------##
+##                                                                                                ##
+##  Initialise CMake - advanced - variables used by the Stòiridh Project to the CMake cache.      ##
+##                                                                                                ##
+####################################################################################################
+function(_STOIRIDH_PROJECT_INITIALISE_CACHE)
+    set(STOIRIDH_INSTALL_ROOT_DIR "install-root" CACHE STRING "Install root directory")
+    set(STOIRIDH_INSTALL_ROOT "${CMAKE_BINARY_DIR}/${STOIRIDH_INSTALL_ROOT_DIR}" CACHE PATH
+        "The install root path where binaries, libraries, and other files will be copied.")
+
+    # project name
+    if(NOT STOIRIDH_PROJECT_NAME)
+        set(STOIRIDH_PROJECT_NAME "${PROJECT_NAME}" CACHE STRING "Project name")
+    else()
+        set(STOIRIDH_PROJECT_NAME "${STOIRIDH_PROJECT_NAME}"
+            CACHE STRING "Project name (User defined)")
+    endif()
+
+    # install directories hierarchy
+    set(STOIRIDH_INSTALL_BINARY_DIR "bin" CACHE STRING "Binary directory")
+    set(STOIRIDH_INSTALL_LIBRARY_DIR "lib" CACHE STRING "Library directory")
+    set(STOIRIDH_INSTALL_INCLUDE_DIR "include" CACHE STRING "Include directory")
+    set(STOIRIDH_INSTALL_PLUGINS_DIR
+        "${STOIRIDH_INSTALL_LIBRARY_DIR}/${STOIRIDH_PROJECT_NAME}/plugins"
+        CACHE STRING "Plugins directory")
+    set(STOIRIDH_INSTALL_QML_DIR "${STOIRIDH_INSTALL_LIBRARY_DIR}/${STOIRIDH_PROJECT_NAME}/qml"
+        CACHE STRING "QML directory")
+    set(STOIRIDH_INSTALL_SHARE_DIR "share" CACHE STRING "Share directory")
+    set(STOIRIDH_INSTALL_DOC_DIR "${STOIRIDH_INSTALL_SHARE_DIR}/doc/${STOIRIDH_PROJECT_NAME}"
+        CACHE STRING "Documentation directory")
+
+    mark_as_advanced(STOIRIDH_INSTALL_ROOT_DIR    STOIRIDH_INSTALL_ROOT
+                     STOIRIDH_INSTALL_BINARY_DIR  STOIRIDH_INSTALL_LIBRARY_DIR
+                     STOIRIDH_INSTALL_INCLUDE_DIR STOIRIDH_INSTALL_PLUGINS_DIR
+                     STOIRIDH_INSTALL_QML_DIR     STOIRIDH_INSTALL_SHARE_DIR
+                     STOIRIDH_INSTALL_DOC_DIR)
+endfunction()

--- a/public/Stoiridh/Install/LocalAPI.cmake
+++ b/public/Stoiridh/Install/LocalAPI.cmake
@@ -1,0 +1,115 @@
+####################################################################################################
+##                                                                                                ##
+##            Copyright (C) 2016 William McKIE                                                    ##
+##                                                                                                ##
+##            This program is free software: you can redistribute it and/or modify                ##
+##            it under the terms of the GNU General Public License as published by                ##
+##            the Free Software Foundation, either version 3 of the License, or                   ##
+##            (at your option) any later version.                                                 ##
+##                                                                                                ##
+##            This program is distributed in the hope that it will be useful,                     ##
+##            but WITHOUT ANY WARRANTY; without even the implied warranty of                      ##
+##            MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                       ##
+##            GNU General Public License for more details.                                        ##
+##                                                                                                ##
+##            You should have received a copy of the GNU General Public License                   ##
+##            along with this program.  If not, see <http://www.gnu.org/licenses/>.               ##
+##                                                                                                ##
+####################################################################################################
+##  stoiridh_install_local_api(HEADERS <header1> [<header2>...]                                   ##
+##                             DESTINATION <relative path>                                        ##
+##                             [FILE_SUFFIXES <suffix1> [<suffix2>...]]                           ##
+##                             [PATH_SUFFIXES <suffix1> [<suffix2>...]]                           ##
+##                             [PUBLIC <header1> [<header2>...]]                                  ##
+##                             [INTERNAL <header1> [<header2>...]]                                ##
+##                             [PRIVATE <header1> [<header2>...]]                                 ##
+##                             [VERSION <version>])                                               ##
+##------------------------------------------------------------------------------------------------##
+##                                                                                                ##
+##  Install a local copy of the API to the relative destination at the STOIRIDH_INSTALL_ROOT      ##
+##  absolute path.                                                                                ##
+##                                                                                                ##
+##  The HEADERS argument corresponds to a list of header files. Those files will be at the root   ##
+##  of the destination path. Any subdirectories containing in the - absolute path - of an header  ##
+##  file will be kept.                                                                            ##
+##                                                                                                ##
+##  The FILE_SUFFIXES argument may be added to replace the default file suffixes. The default     ##
+##  file suffixes are .h, .hpp, .hxx, .inl, and .tpp. Also note, the *.* before the file suffix   ##
+##  is important.                                                                                 ##
+##                                                                                                ##
+##  The PATH_SUFFIXES argument corresponds to a list of relative paths where this function will   ##
+##  concatenate with the CMAKE_CURRENT_LIST_DIR variable in order to avoid the keep those paths   ##
+##  during copying of the header files.                                                           ##
+##                                                                                                ##
+##  The PUBLIC, INERNAL, and PRIVATE optional arguments correspond to a list of header files      ##
+##  that will be copied at the root of the destination path following by an optional version      ##
+##  directory and a public, internal, and private directory, respectively.                        ##
+##                                                                                                ##
+##  Note: Any subdirectories provided by any header files will be kept.                           ##
+##                                                                                                ##
+####################################################################################################
+function(STOIRIDH_INSTALL_LOCAL_API)
+    stoiridh_include("Stoiridh.Utility.Header" INTERNAL)
+
+    set(OVK "DESTINATION" "VERSION")
+    set(MVK "HEADERS" "PUBLIC" "INTERNAL" "PRIVATE" "FILE_SUFFIXES" "PATH_SUFFIXES")
+    cmake_parse_arguments(STOIRIDH_COMMAND "" "${OVK}" "${MVK}" ${ARGN})
+
+    if(NOT STOIRIDH_COMMAND_HEADERS)
+        message(FATAL_ERROR "stoiridh_install_local_api: HEADERS is missing.")
+    endif()
+
+    if(NOT STOIRIDH_COMMAND_DESTINATION)
+        message(FATAL_ERROR "stoiridh_install_local_api: DESTINATION is missing.")
+    endif()
+
+    if(NOT STOIRIDH_COMMAND_FILE_SUFFIXES)
+        set(HEADER_SUFFIXES ".h;.hpp;.hxx;.inl;.tpp")
+    else()
+        set(HEADER_SUFFIXES "${STOIRIDH_COMMAND_FILE_SUFFIXES}")
+    endif()
+
+    if(NOT STOIRIDH_INSTALL_ROOT)
+        message(WARNING "stoiridh_install_local_api: No STOIRIDH_INSTALL_ROOT set within the cache.
+            Either set manually the variable with CMake or call stoiridh_project_initialise()
+            function at the top-level of your project.")
+        return()
+    endif()
+
+    set(INCLUDE_ROOT_PATH
+        "${STOIRIDH_INSTALL_ROOT}/${STOIRIDH_INSTALL_INCLUDE_DIR}/${STOIRIDH_COMMAND_DESTINATION}")
+
+    # copy HEADERS into INCLUDE_ROOT_PATH
+    stoiridh_utility_header(COPY
+                            HEADERS ${STOIRIDH_COMMAND_HEADERS}
+                            DESTINATION ${INCLUDE_ROOT_PATH}
+                            PATH_SUFFIXES ${STOIRIDH_COMMAND_PATH_SUFFIXES})
+
+    # filter the following commands in order to retrieve only the header files
+    if(STOIRIDH_COMMAND_PUBLIC)
+        set(PUBLIC_INCLUDE_PATH "${INCLUDE_ROOT_PATH}/${STOIRIDH_COMMAND_VERSION}/public")
+        stoiridh_utility_header(FILTER_COPY
+                                HEADERS ${STOIRIDH_COMMAND_PUBLIC}
+                                HEADER_SUFFIXES ${HEADER_SUFFIXES}
+                                PATH_SUFFIXES ${STOIRIDH_COMMAND_PATH_SUFFIXES}
+                                DESTINATION ${PUBLIC_INCLUDE_PATH})
+    endif()
+
+    if(STOIRIDH_COMMAND_INTERNAL)
+        set(INTERNAL_INCLUDE_PATH "${INCLUDE_ROOT_PATH}/${STOIRIDH_COMMAND_VERSION}/internal")
+        stoiridh_utility_header(FILTER_COPY
+                                HEADERS ${STOIRIDH_COMMAND_INTERNAL}
+                                HEADER_SUFFIXES ${HEADER_SUFFIXES}
+                                PATH_SUFFIXES ${STOIRIDH_COMMAND_PATH_SUFFIXES}
+                                DESTINATION ${INTERNAL_INCLUDE_PATH})
+    endif()
+
+    if(STOIRIDH_COMMAND_PRIVATE)
+        set(PRIVATE_INCLUDE_PATH "${INCLUDE_ROOT_PATH}/${STOIRIDH_COMMAND_VERSION}/private")
+        stoiridh_utility_header(FILTER_COPY
+                                HEADERS ${STOIRIDH_COMMAND_PRIVATE}
+                                HEADER_SUFFIXES ${HEADER_SUFFIXES}
+                                PATH_SUFFIXES ${STOIRIDH_COMMAND_PATH_SUFFIXES}
+                                DESTINATION ${PRIVATE_INCLUDE_PATH})
+    endif()
+endfunction()

--- a/public/Stoiridh/Qt/Application.cmake
+++ b/public/Stoiridh/Qt/Application.cmake
@@ -1,0 +1,81 @@
+####################################################################################################
+##                                                                                                ##
+##            Copyright (C) 2016 William McKIE                                                    ##
+##                                                                                                ##
+##            This program is free software: you can redistribute it and/or modify                ##
+##            it under the terms of the GNU General Public License as published by                ##
+##            the Free Software Foundation, either version 3 of the License, or                   ##
+##            (at your option) any later version.                                                 ##
+##                                                                                                ##
+##            This program is distributed in the hope that it will be useful,                     ##
+##            but WITHOUT ANY WARRANTY; without even the implied warranty of                      ##
+##            MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                       ##
+##            GNU General Public License for more details.                                        ##
+##                                                                                                ##
+##            You should have received a copy of the GNU General Public License                   ##
+##            along with this program.  If not, see <http://www.gnu.org/licenses/>.               ##
+##                                                                                                ##
+####################################################################################################
+stoiridh_include("Stoiridh.Qt.Helper" INTERNAL)
+
+####################################################################################################
+##  stoiridh_qt_add_application(<target> [ALIAS <alias>]                                          ##
+##                             SOURCES <source1> [<source2>...]                                   ##
+##                             DEPENDS <dependency1> [<dependency2>...]                           ##
+##                             [OTHER_FILES <file1> [<file2>...]]                                 ##
+##                             [USE_QT_PRIVATE_API])                                              ##
+##                                                                                                ##
+##------------------------------------------------------------------------------------------------##
+##                                                                                                ##
+##  Add an application to the project.                                                            ##
+##                                                                                                ##
+##  An <alias> can be set to the <target> in order to be linked with an elegant name in others    ##
+##  projects.                                                                                     ##
+##                                                                                                ##
+##  If the OTHER_FILES argument is specified, then the other files will be added to the target    ##
+##  without to be compiled. This option is useful to append some extra files in the project view  ##
+## of an IDE, e.g., QtCreator.                                                                    ##
+##                                                                                                ##
+##  If the USE_QT_PRIVATE_API option is specified, the header files from the Qt's private API     ##
+##  will be added to <target>.                                                                    ##
+##                                                                                                ##
+##  Note: This function is targeting a C++14 compiler and Qt5 API.                                ##
+##                                                                                                ##
+####################################################################################################
+function(STOIRIDH_QT_ADD_APPLICATION target)
+    set(OPTIONS "USE_QT_PRIVATE_API")
+    set(OVK "ALIAS")
+    set(MVK "SOURCES" "DEPENDS" "OTHER_FILES")
+    cmake_parse_arguments(STOIRIDH_COMMAND "${OPTIONS}" "${OVK}" "${MVK}" ${ARGN})
+
+    if(NOT STOIRIDH_COMMAND_SOURCES)
+        message(FATAL_ERROR "stoiridh_qt_add_application: SOURCES is missing or not defined.")
+    endif()
+
+    if(NOT STOIRIDH_COMMAND_DEPENDS)
+        message(FATAL_ERROR "stoiridh_qt_add_application: DEPENDS is missing or not defined.")
+    endif()
+
+    set(USER_OPTIONS)
+
+    if(STOIRIDH_COMMAND_USE_QT_PRIVATE_API)
+        set(USER_OPTIONS "${USER_OPTIONS}" "USE_QT_PRIVATE_API")
+    endif()
+
+    # create the application
+    stoiridh_qt_helper(APPLICATION ${target}
+                       SOURCES ${STOIRIDH_COMMAND_SOURCES}
+                       DEPENDS ${STOIRIDH_COMMAND_DEPENDS}
+                       OTHER_FILES ${STOIRIDH_COMMAND_OTHER_FILES}
+                       ${USER_OPTIONS})
+
+    unset(USER_OPTIONS)
+
+    # make an alias of the library for CMake use, e.g., <PROJECT_NAME>::<SUBPROJECT_NAME>.
+    if(STOIRIDH_COMMAND_ALIAS)
+        add_executable(${STOIRIDH_COMMAND_ALIAS} ALIAS ${target})
+    endif()
+
+    # add the install rule
+    install(TARGETS ${target} RUNTIME DESTINATION ${STOIRIDH_INSTALL_BINARY_DIR})
+endfunction()

--- a/public/Stoiridh/Qt/Library.cmake
+++ b/public/Stoiridh/Qt/Library.cmake
@@ -1,0 +1,92 @@
+####################################################################################################
+##                                                                                                ##
+##            Copyright (C) 2016 William McKIE                                                    ##
+##                                                                                                ##
+##            This program is free software: you can redistribute it and/or modify                ##
+##            it under the terms of the GNU General Public License as published by                ##
+##            the Free Software Foundation, either version 3 of the License, or                   ##
+##            (at your option) any later version.                                                 ##
+##                                                                                                ##
+##            This program is distributed in the hope that it will be useful,                     ##
+##            but WITHOUT ANY WARRANTY; without even the implied warranty of                      ##
+##            MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                       ##
+##            GNU General Public License for more details.                                        ##
+##                                                                                                ##
+##            You should have received a copy of the GNU General Public License                   ##
+##            along with this program.  If not, see <http://www.gnu.org/licenses/>.               ##
+##                                                                                                ##
+####################################################################################################
+stoiridh_include("Stoiridh.Qt.Helper" INTERNAL)
+
+####################################################################################################
+##  stoiridh_qt_add_library(<target> [ALIAS <alias>]                                              ##
+##                          SOURCES <source1> [<source2>...]                                      ##
+##                          DEPENDS <dependency1> [<dependency2>...]                              ##
+##                          [OTHER_FILES <file1> [<file2>...]]                                    ##
+##                          [USE_QT_PRIVATE_API])                                                 ##
+##                                                                                                ##
+##------------------------------------------------------------------------------------------------##
+##                                                                                                ##
+##  Add a Qt shared library to the project.                                                       ##
+##                                                                                                ##
+##  An <alias> can be set to the <target> in order to be linked with an elegant name in others    ##
+##  projects.                                                                                     ##
+##                                                                                                ##
+##  If the OTHER_FILES argument is specified, then the other files will be added to the target    ##
+##  without to be compiled. This option is useful to append some extra files in the project view  ##
+##  of an IDE, e.g., QtCreator.                                                                   ##
+##                                                                                                ##
+##  If the USE_QT_PRIVATE_API option is specified, the header files from the Qt's private API     ##
+##  will be added to <target>.                                                                    ##
+##                                                                                                ##
+##  Note: This function is targeting a C++14 compiler and Qt5 API.                                ##
+##                                                                                                ##
+####################################################################################################
+function(STOIRIDH_QT_ADD_LIBRARY target)
+    set(OPTIONS "USE_QT_PRIVATE_API")
+    set(OVK "ALIAS")
+    set(MVK "SOURCES" "DEPENDS" "OTHER_FILES")
+    cmake_parse_arguments(STOIRIDH_COMMAND "${OPTIONS}" "${OVK}" "${MVK}" ${ARGN})
+
+    if(NOT STOIRIDH_COMMAND_SOURCES)
+        message(FATAL_ERROR "stoiridh_qt_add_library: SOURCES is missing or not defined.")
+    endif()
+
+    if(NOT STOIRIDH_COMMAND_DEPENDS)
+        message(FATAL_ERROR "stoiridh_qt_add_library: DEPENDS is missing or not defined.")
+    endif()
+
+    set(USER_OPTIONS)
+
+    if(STOIRIDH_COMMAND_USE_QT_PRIVATE_API)
+        set(USER_OPTIONS "${USER_OPTIONS}" "USE_QT_PRIVATE_API")
+    endif()
+
+    # create the shared library
+    stoiridh_qt_helper(LIBRARY ${target}
+                       SOURCES ${STOIRIDH_COMMAND_SOURCES}
+                       DEPENDS ${STOIRIDH_COMMAND_DEPENDS}
+                       OTHER_FILES ${STOIRIDH_COMMAND_OTHER_FILES}
+                       ${USER_OPTIONS})
+
+    unset(USER_OPTIONS)
+
+    # move the library either into the 'bin' or 'lib' directory depends on the Operating System.
+    if(STOIRIDH_OS_WINDOWS)
+        set(INSTALL_ROOT_DIR "${STOIRIDH_INSTALL_ROOT}/${STOIRIDH_INSTALL_BINARY_DIR}")
+        set_target_properties(${target} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${INSTALL_ROOT_DIR})
+    elseif(STOIRIDH_OS_LINUX)
+        set(INSTALL_ROOT_DIR "${STOIRIDH_INSTALL_ROOT}/${STOIRIDH_INSTALL_LIBRARY_DIR}")
+        set_target_properties(${target} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${INSTALL_ROOT_DIR})
+    endif()
+
+    # make an alias of the library for CMake use, e.g., <PROJECT_NAME>::<SUBPROJECT_NAME>.
+    if(STOIRIDH_COMMAND_ALIAS)
+        add_library(${STOIRIDH_COMMAND_ALIAS} ALIAS ${target})
+    endif()
+
+    # add the install rule
+    install(TARGETS ${target}
+            RUNTIME DESTINATION ${STOIRIDH_INSTALL_BINARY_DIR}
+            LIBRARY DESTINATION ${STOIRIDH_INSTALL_LIBRARY_DIR})
+endfunction()

--- a/public/Stoiridh/Qt/Plugin.cmake
+++ b/public/Stoiridh/Qt/Plugin.cmake
@@ -1,0 +1,76 @@
+####################################################################################################
+##                                                                                                ##
+##            Copyright (C) 2016 William McKIE                                                    ##
+##                                                                                                ##
+##            This program is free software: you can redistribute it and/or modify                ##
+##            it under the terms of the GNU General Public License as published by                ##
+##            the Free Software Foundation, either version 3 of the License, or                   ##
+##            (at your option) any later version.                                                 ##
+##                                                                                                ##
+##            This program is distributed in the hope that it will be useful,                     ##
+##            but WITHOUT ANY WARRANTY; without even the implied warranty of                      ##
+##            MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                       ##
+##            GNU General Public License for more details.                                        ##
+##                                                                                                ##
+##            You should have received a copy of the GNU General Public License                   ##
+##            along with this program.  If not, see <http://www.gnu.org/licenses/>.               ##
+##                                                                                                ##
+####################################################################################################
+stoiridh_include("Stoiridh.Qt.Library")
+
+####################################################################################################
+##  stoiridh_qt_add_plugin(<target> [ALIAS <alias>]                                               ##
+##                         SOURCES <source1> [<source2>...]                                       ##
+##                         DEPENDS <dependency1> [<dependency2>...]                               ##
+##                         [OTHER_FILES <file1> [<file2>...]]                                     ##
+##                         [USE_QT_PRIVATE_API])                                                  ##
+##                                                                                                ##
+##------------------------------------------------------------------------------------------------##
+##                                                                                                ##
+##  Add a Qt plugin to the project.                                                               ##
+##                                                                                                ##
+##  An <alias> can be set to the <target> in order to be linked with an elegant name in others    ##
+##  projects.                                                                                     ##
+##                                                                                                ##
+##  If the OTHER_FILES argument is given, then other files will be added to the target without    ##
+##  to be compiled. This option is useful to append some extra files in the project view of an    ##
+##  IDE, e.g., QtCreator.                                                                         ##
+##                                                                                                ##
+##  If the USE_QT_PRIVATE_API option is given, the header files from the Qt's private API will    ##
+##  be added to <target>.                                                                         ##
+##                                                                                                ##
+##  Note: This function is targeting a C++14 compiler and Qt5 API.                                ##
+##                                                                                                ##
+####################################################################################################
+function(STOIRIDH_QT_ADD_PLUGIN target)
+    set(OPTIONS "USE_QT_PRIVATE_API")
+    set(OVK "ALIAS")
+    set(MVK "SOURCES" "DEPENDS" "OTHER_FILES")
+    cmake_parse_arguments(STOIRIDH_COMMAND "${OPTIONS}" "${OVK}" "${MVK}" ${ARGN})
+
+    if(NOT STOIRIDH_COMMAND_SOURCES)
+        message(FATAL_ERROR "stoiridh_qt_add_library: SOURCES is missing or not defined.")
+    endif()
+
+    if(NOT STOIRIDH_COMMAND_DEPENDS)
+        message(FATAL_ERROR "stoiridh_qt_add_library: DEPENDS is missing or not defined.")
+    endif()
+
+    set(USER_OPTIONS)
+
+    if(STOIRIDH_COMMAND_USE_QT_PRIVATE_API)
+        set(USER_OPTIONS "${USER_OPTIONS}" "USE_QT_PRIVATE_API")
+    endif()
+
+    stoiridh_qt_add_library(${target}
+                            ALIAS ${STOIRIDH_COMMAND_ALIAS}
+                            SOURCES ${STOIRIDH_COMMAND_SOURCES}
+                            DEPENDS ${STOIRIDH_COMMAND_DEPENDS}
+                            OTHER_FILES ${STOIRIDH_COMMAND_OTHER_FILES}
+                            ${USER_OPTIONS})
+
+    unset(USER_OPTIONS)
+
+    # remove the 'lib' prefix for a Qt5 plugin.
+    set_target_properties(${target} PROPERTIES IMPORT_PREFIX "" PREFIX "")
+endfunction()

--- a/public/Stoiridh/Qt/Qml/ExtensionPlugin.cmake
+++ b/public/Stoiridh/Qt/Qml/ExtensionPlugin.cmake
@@ -1,0 +1,109 @@
+####################################################################################################
+##                                                                                                ##
+##            Copyright (C) 2016 William McKIE                                                    ##
+##                                                                                                ##
+##            This program is free software: you can redistribute it and/or modify                ##
+##            it under the terms of the GNU General Public License as published by                ##
+##            the Free Software Foundation, either version 3 of the License, or                   ##
+##            (at your option) any later version.                                                 ##
+##                                                                                                ##
+##            This program is distributed in the hope that it will be useful,                     ##
+##            but WITHOUT ANY WARRANTY; without even the implied warranty of                      ##
+##            MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                       ##
+##            GNU General Public License for more details.                                        ##
+##                                                                                                ##
+##            You should have received a copy of the GNU General Public License                   ##
+##            along with this program.  If not, see <http://www.gnu.org/licenses/>.               ##
+##                                                                                                ##
+####################################################################################################
+stoiridh_include("Stoiridh.Qt.Qml.Module")
+stoiridh_include("Stoiridh.Qt.Helper" INTERNAL)
+
+####################################################################################################
+##  stoiridh_qt_qml_add_module(<target> [ALIAS <alias>]                                           ##
+##                             URI <uri>                                                          ##
+##                             SOURCES <source1> [<source2>...]                                   ##
+##                             QML_SOURCES <source1> [<source2>...]                               ##
+##                             DEPENDS <dependency1> [<dependency2>...]                           ##
+##                             [QML_PATH_SUFFIXES <suffix1> [<suffix2>...]])                      ##
+##                             [OTHER_FILES <file1> [<file2>...]]                                 ##
+##------------------------------------------------------------------------------------------------##
+##                                                                                                ##
+##  Add a QtQml extension plugin to the project using the specified sources and Qml sources.      ##
+##                                                                                                ##
+##  An <alias> can be set to the <target> in order to be linked with an elegant name in others    ##
+##  projects.                                                                                     ##
+##                                                                                                ##
+##  The URI argument is an identifier (URI dotted notation) for the module, which must match the  ##
+##  module's install path.                                                                        ##
+##                                                                                                ##
+##  The QML_PATH_SUFFIXES argument corresponds to a list of relative paths where this function    ##
+##  will concatenate with the CMAKE_CURRENT_LIST_DIR variable in order to avoid the keep those    ##
+##  paths during copying of the header files.                                                     ##
+##                                                                                                ##
+##  If the OTHER_FILES argument is specified, then the other files will be added to the target    ##
+##  without to be compiled. This option is useful to append some extra files in the project view  ##
+##  of an IDE, e.g., QtCreator.                                                                   ##
+##                                                                                                ##
+##  Note: This function is targeting a C++14 compiler and Qt5 API.                                ##
+##                                                                                                ##
+####################################################################################################
+function(STOIRIDH_QT_QML_ADD_EXTENSION_PLUGIN target)
+    set(OVK "ALIAS" "URI")
+    set(MVK "DEPENDS" "QML_PATH_SUFFIXES" "QML_SOURCES" "SOURCES" "OTHER_FILES")
+    cmake_parse_arguments(STOIRIDH_COMMAND "" "${OVK}" "${MVK}" ${ARGN})
+
+    if(NOT STOIRIDH_COMMAND_DEPENDS)
+        message(FATAL_ERROR "stoiridh_qt_qml_add_extension_plugin: DEPENDS is missing or not "
+                            "defined.")
+    endif()
+
+    if(NOT STOIRIDH_COMMAND_QML_SOURCES)
+        message(FATAL_ERROR "stoiridh_qt_qml_add_extension_plugin: QML_SOURCES is missing or not "
+                            "defined.")
+    endif()
+
+    if(NOT STOIRIDH_COMMAND_SOURCES)
+        message(FATAL_ERROR "stoiridh_qt_qml_add_extension_plugin: SOURCES is missing or not "
+                            "defined.")
+    endif()
+
+    if(NOT STOIRIDH_COMMAND_URI)
+        message(FATAL_ERROR "stoiridh_qt_qml_add_extension_plugin: URI is missing or not defined.")
+    endif()
+
+    # a QtQml extension plugin is inherently a QtQml module.
+    stoiridh_qt_qml_add_module(${target}
+                               URI ${STOIRIDH_COMMAND_URI}
+                               SOURCES ${STOIRIDH_COMMAND_QML_SOURCES}
+                               OTHER_FILES ${STOIRIDH_COMMAND_OTHER_FILES}
+                               PATH_SUFFIXES ${STOIRIDH_COMMAND_QML_PATH_SUFFIXES})
+
+    # create the shared library
+    stoiridh_qt_helper(LIBRARY ${target}
+                       SOURCES ${STOIRIDH_COMMAND_SOURCES}
+                       DEPENDS ${STOIRIDH_COMMAND_DEPENDS})
+
+    # remove the 'lib' prefix for QtQml plugin.
+    set_target_properties(${target} PROPERTIES IMPORT_PREFIX "" PREFIX "")
+
+    # move the library either into the 'bin' or 'lib' directory depends on the Operating System.
+    string(REPLACE "." "/" MODULE_NAME ${STOIRIDH_COMMAND_URI})
+    set(INSTALL_ROOT_DIR "${STOIRIDH_INSTALL_ROOT}/${STOIRIDH_INSTALL_QML_DIR}/${MODULE_NAME}")
+
+    if(STOIRIDH_OS_WINDOWS)
+        set_target_properties(${target} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${INSTALL_ROOT_DIR})
+    elseif(STOIRIDH_OS_LINUX)
+        set_target_properties(${target} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${INSTALL_ROOT_DIR})
+    endif()
+
+    # make an alias of the library for CMake use, e.g., <PROJECT_NAME>::<SUBPROJECT_NAME>.
+    if(STOIRIDH_COMMAND_ALIAS)
+        add_library(${STOIRIDH_COMMAND_ALIAS} ALIAS ${target})
+    endif()
+
+    # add the install rule.
+    install(TARGETS ${target}
+            RUNTIME DESTINATION ${STOIRIDH_INSTALL_QML_DIR}
+            LIBRARY DESTINATION ${STOIRIDH_INSTALL_QML_DIR})
+endfunction()

--- a/public/Stoiridh/Qt/Qml/Module.cmake
+++ b/public/Stoiridh/Qt/Qml/Module.cmake
@@ -1,0 +1,63 @@
+####################################################################################################
+##                                                                                                ##
+##            Copyright (C) 2016 William McKIE                                                    ##
+##                                                                                                ##
+##            This program is free software: you can redistribute it and/or modify                ##
+##            it under the terms of the GNU General Public License as published by                ##
+##            the Free Software Foundation, either version 3 of the License, or                   ##
+##            (at your option) any later version.                                                 ##
+##                                                                                                ##
+##            This program is distributed in the hope that it will be useful,                     ##
+##            but WITHOUT ANY WARRANTY; without even the implied warranty of                      ##
+##            MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                       ##
+##            GNU General Public License for more details.                                        ##
+##                                                                                                ##
+##            You should have received a copy of the GNU General Public License                   ##
+##            along with this program.  If not, see <http://www.gnu.org/licenses/>.               ##
+##                                                                                                ##
+####################################################################################################
+stoiridh_include("Stoiridh.Utility.LocalInstall" INTERNAL)
+
+####################################################################################################
+##  stoiridh_qt_qml_add_module(<target>                                                           ##
+##                             URI <uri>                                                          ##
+##                             SOURCES <source1> [<source2>...]                                   ##
+##                             [OTHER_FILES <file1> [<file2>...]]                                 ##
+##                             [PATH_SUFFIXES <suffix1> [<suffix2>...]])                          ##
+##------------------------------------------------------------------------------------------------##
+##                                                                                                ##
+##  Add a QtQml module to the project using the specified sources.                                ##
+##                                                                                                ##
+##  The URI argument is an identifier (URI dotted notation) for the module, which must match the  ##
+##  module's install path.                                                                        ##
+##                                                                                                ##
+##  The PATH_SUFFIXES argument corresponds to a list of relative paths where this function will   ##
+##  concatenate with the CMAKE_CURRENT_LIST_DIR variable in order to avoid the keep those paths   ##
+##  during copying of the header files.                                                           ##
+##                                                                                                ##
+####################################################################################################
+function(STOIRIDH_QT_QML_ADD_MODULE target)
+    set(OVK "URI")
+    set(MVK "OTHER_FILES" "PATH_SUFFIXES" "SOURCES")
+    cmake_parse_arguments(STOIRIDH_COMMAND "" "${OVK}" "${MVK}" ${ARGN})
+
+    if(NOT STOIRIDH_COMMAND_URI)
+        message(FATAL_ERROR "stoiridh_qt_qml_add_module: URI is missing or not defined.")
+    endif()
+
+    if(NOT STOIRIDH_COMMAND_SOURCES)
+        message(FATAL_ERROR "stoiridh_qt_qml_add_module: SOURCES is missing or not defined.")
+    endif()
+
+    string(REPLACE "." "/" MODULE_NAME ${STOIRIDH_COMMAND_URI})
+    set(INSTALL_ROOT_DIR "${STOIRIDH_INSTALL_ROOT}/${STOIRIDH_INSTALL_QML_DIR}/${MODULE_NAME}")
+
+    stoiridh_utility_local_install(FILES ${STOIRIDH_COMMAND_SOURCES}
+                                   DESTINATION ${INSTALL_ROOT_DIR}
+                                   PATH_SUFFIXES ${STOIRIDH_COMMAND_PATH_SUFFIXES})
+
+    if(STOIRIDH_COMMAND_OTHER_FILES)
+        add_custom_target("${target}_OTHER_FILES"
+                          SOURCES ${STOIRIDH_COMMAND_SOURCES} ${STOIRIDH_COMMAND_OTHER_FILES})
+    endif()
+endfunction()


### PR DESCRIPTION
Add the possibility to add a Qt Application, Library (Shared), Plugin, Qml
Extension Plugin, and Qml Module to a project.

Unlike CMake traditional include system, Stòiridh CMake Tools uses a module
system (with URI dotted notation) in order to include a CMake file.

stoiridh_include(<module_name> [INTERNAL])

Example:

stoiridh_include("Stoiridh.Qt.Application")

When included, we can use the following function:

stoiridh_qt_add_application(<target> SOURCES <sources> DEPENDS <depends>)